### PR TITLE
Terraform resources have required providers

### DIFF
--- a/docs/rules/terraform_resouces_have_required_providers.md
+++ b/docs/rules/terraform_resouces_have_required_providers.md
@@ -1,0 +1,55 @@
+# terraform_resouces_have_required_providers
+
+Require that all resources have version constraints declared through `required_providers`.
+
+## Configuration
+
+```hcl
+rule "terraform_resources_have_required_providers" {
+  enabled = true
+}
+```
+
+## Examples
+
+```hcl
+terraform {
+ required_providers {
+ }
+}
+
+resource "template_test" "example" {
+}
+
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: `Missing version constraint for provider "template" in "required_providers"
+
+  on main.tf line 6:
+   1: provider "template" {}
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.18.0/docs/rules/terraform_resources_have_required_providers.md
+```
+
+
+## Why
+
+Providers are plugins released on a separate rhythm from Terraform itself, and so they have their own version numbers. For production use, you should constrain the acceptable provider versions via configuration, to ensure that new versions with breaking changes will not be automatically installed by `terraform init` in future.
+
+## How To Fix
+
+Add the [`required_providers`](https://www.terraform.io/docs/configuration/terraform.html#specifying-required-provider-versions) block to the `terraform` configuration block and include current versions for all providers. For example:
+
+```tf
+terraform {
+  required_providers {
+    template = "~> 2.0"
+  }
+}
+```
+
+Provider version constraints can be specified using a [version argument within a provider block](https://www.terraform.io/docs/configuration/providers.html#provider-versions) for backwards compatability. This approach is now discouraged, particularly for child modules. This usage is unsupported by this rule.

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -50,6 +50,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformWorkspaceRemoteRule(),
 	terraformrules.NewTerraformUnusedDeclarationsRule(),
 	terraformrules.NewTerraformCommentSyntaxRule(),
+	terraformrules.NewTerraformResourcesHaveRequiredProviders(),
 }
 
 var manualDeepCheckRules = []Rule{

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -50,7 +50,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformWorkspaceRemoteRule(),
 	terraformrules.NewTerraformUnusedDeclarationsRule(),
 	terraformrules.NewTerraformCommentSyntaxRule(),
-	terraformrules.NewTerraformResourcesHaveRequiredProviders(),
+	terraformrules.NewTerraformResourcesHaveRequiredProvidersRule(),
 }
 
 var manualDeepCheckRules = []Rule{

--- a/rules/terraformrules/terraform_resources_have_required_providers.go
+++ b/rules/terraformrules/terraform_resources_have_required_providers.go
@@ -8,36 +8,36 @@ import (
 	"github.com/terraform-linters/tflint/tflint"
 )
 
-// TerraformResourcesHaveRequiredProviders checks whether Terraform sets version constraints for all declared resources
-type TerraformResourcesHaveRequiredProviders struct{}
+// TerraformResourcesHaveRequiredProvidersRule checks whether Terraform sets version constraints for all declared resources
+type TerraformResourcesHaveRequiredProvidersRule struct{}
 
-// NewTerraformResourcesHaveRequiredProviders returns new rule with default attributes
-func NewTerraformResourcesHaveRequiredProviders() *TerraformResourcesHaveRequiredProviders {
-	return &TerraformResourcesHaveRequiredProviders{}
+// NewTerraformResourcesHaveRequiredProvidersRule returns new rule with default attributes
+func NewTerraformResourcesHaveRequiredProvidersRule() *TerraformResourcesHaveRequiredProvidersRule {
+	return &TerraformResourcesHaveRequiredProvidersRule{}
 }
 
 // Name returns the rule name
-func (r *TerraformResourcesHaveRequiredProviders) Name() string {
+func (r *TerraformResourcesHaveRequiredProvidersRule) Name() string {
 	return "terraform_resources_have_required_providers"
 }
 
 // Enabled returns whether the rule is enabled by default
-func (r *TerraformResourcesHaveRequiredProviders) Enabled() bool {
+func (r *TerraformResourcesHaveRequiredProvidersRule) Enabled() bool {
 	return false
 }
 
 // Severity returns the rule severity
-func (r *TerraformResourcesHaveRequiredProviders) Severity() string {
+func (r *TerraformResourcesHaveRequiredProvidersRule) Severity() string {
 	return tflint.WARNING
 }
 
 // Link returns the rule reference link
-func (r *TerraformResourcesHaveRequiredProviders) Link() string {
+func (r *TerraformResourcesHaveRequiredProvidersRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
 // Check checks whether declared resources have valid version constraints
-func (r *TerraformResourcesHaveRequiredProviders) Check(runner *tflint.Runner) error {
+func (r *TerraformResourcesHaveRequiredProvidersRule) Check(runner *tflint.Runner) error {
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	resources := make(map[string]hcl.Range)

--- a/rules/terraformrules/terraform_resources_have_required_providers.go
+++ b/rules/terraformrules/terraform_resources_have_required_providers.go
@@ -1,0 +1,59 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformResourcesHaveRequiredProviders checks whether Terraform sets version constraints for all declared resources
+type TerraformResourcesHaveRequiredProviders struct{}
+
+// NewTerraformResourcesHaveRequiredProviders returns new rule with default attributes
+func NewTerraformResourcesHaveRequiredProviders() *TerraformResourcesHaveRequiredProviders {
+	return &TerraformResourcesHaveRequiredProviders{}
+}
+
+// Name returns the rule name
+func (r *TerraformResourcesHaveRequiredProviders) Name() string {
+	return "terraform_resources_have_required_providers"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformResourcesHaveRequiredProviders) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformResourcesHaveRequiredProviders) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformResourcesHaveRequiredProviders) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether declared resources have valid version constraints
+func (r *TerraformResourcesHaveRequiredProviders) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	resources := make(map[string]hcl.Range)
+	module := runner.TFConfig.Module
+
+	for _, res := range module.ManagedResources {
+		if _, ok := resources[res.Provider.Type]; !ok {
+			resources[res.Provider.Type] = res.DeclRange
+		}
+	}
+
+	for name, decl := range resources {
+		if _, ok := module.ProviderRequirements.RequiredProviders[name]; !ok {
+			runner.EmitIssue(r, fmt.Sprintf(`Missing version constraint for provider "%s" in "required_providers"`, name), decl)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_resources_have_required_providers.go
+++ b/rules/terraformrules/terraform_resources_have_required_providers.go
@@ -45,7 +45,11 @@ func (r *TerraformResourcesHaveRequiredProvidersRule) Check(runner *tflint.Runne
 
 	for _, res := range module.ManagedResources {
 		if _, ok := resources[res.Provider.Type]; !ok {
-			resources[res.Provider.Type] = res.DeclRange
+			providerName := res.Provider.Type
+			if res.ProviderConfigRef != nil {
+				providerName = res.ProviderConfigRef.Alias
+			}
+			resources[providerName] = res.DeclRange
 		}
 	}
 

--- a/rules/terraformrules/terraform_resources_have_required_providers_test.go
+++ b/rules/terraformrules/terraform_resources_have_required_providers_test.go
@@ -1,0 +1,50 @@
+package terraformrules
+
+import (
+	"testing"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformResourcesHaveRequiredProviders(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+
+		{
+			Name: "version set",
+			Content: `
+terraform {
+  required_providers {
+	azuread = "1.0"
+  }
+}
+
+
+resource "azuread_application" "example" {
+ name = "ExampleApp"
+}
+
+`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformResourcesHaveRequiredProviders()
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := tflint.TestRunner(t, map[string]string{"module.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			tflint.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/terraformrules/terraform_resources_have_required_providers_test.go
+++ b/rules/terraformrules/terraform_resources_have_required_providers_test.go
@@ -32,7 +32,7 @@ resource "azuread_application" "example" {
 		},
 	}
 
-	rule := NewTerraformResourcesHaveRequiredProviders()
+	rule := NewTerraformResourcesHaveRequiredProvidersRule()
 
 	for _, tc := range cases {
 		tc := tc


### PR DESCRIPTION
Adds functionality to ensure all resources are declared in required_providers and pinned to a version number.